### PR TITLE
Added support for Chronos HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,24 @@ The parameter settings will be found under the `parameters` property:
 ```yml
 parameters:
     chronos_url: http://your.chronos.url:chronos_api_port/
+    chronos_http_username: username
+    chronos_http_password: password
     repository_dir: /path/to/your/local/job/repository
     cache_dir: /path/to/chapi/cache/dir
 ```
 
 #### chronos_url
 The chronos api url (inclusive port). Look also under the [configure command](#configure) option `-u`.
+
+#### chronos_http_username
+The chronos http username. Look also under the [configure command](#configure) option `-un`.
+
+Necessary if the setting `--http_credentials` is activated in your Chronos instance.
+
+#### chronos_http_password
+The chronos http password. Look also under the [configure command](#configure) option `-un`.
+
+Necessary if the setting `--http_credentials` is activated in your Chronos instance.
 
 #### repository_dir
 Root path to your job files. Look also under the [configure command](#configure) option `-r`.
@@ -147,6 +159,8 @@ bin/chapi configure
 
     Options:
       -u, --chronos_url[=CHRONOS_URL]        The chronos url (inclusive port)
+      -un, --chronos_http_username[=CHRONOS_HTTP_USERNAME]  The chronos username (HTTP credentials) [default: ""]
+      -p, --chronos_http_password[=CHRONOS_HTTP_PASSWORD]   The chronos password (HTTP credentials) [default: ""]
       -d, --cache_dir[=CACHE_DIR]            Path to cache directory
       -r, --repository_dir[=REPOSITORY_DIR]  Root path to your job files
       

--- a/app/Resources/config/component/http_client.yml
+++ b/app/Resources/config/component/http_client.yml
@@ -3,11 +3,15 @@ services:
     class: Chapi\Component\Http\HttpGuzzlClient
     arguments:
       - "@ExternalGuzzleClientInterface"
-      -
-        username: "%chronos_http_username%"
-        password: "%chronos_http_password%"
+      - "@HttpAuthEntity"
 
   ExternalGuzzleClientInterface:
     class: GuzzleHttp\Client
     arguments:
       - base_url: "%chronos_url%"
+
+  HttpAuthEntity:
+    class: Chapi\Entity\Http\AuthEntity
+    arguments:
+      - "%chronos_http_username%"
+      - "%chronos_http_password%"

--- a/app/Resources/config/component/http_client.yml
+++ b/app/Resources/config/component/http_client.yml
@@ -1,7 +1,11 @@
 services:
   HttpClientGuzzle:
     class: Chapi\Component\Http\HttpGuzzlClient
-    arguments: ["@ExternalGuzzleClientInterface"]
+    arguments:
+      - "@ExternalGuzzleClientInterface"
+      -
+        username: "%chronos_http_username%"
+        password: "%chronos_http_password%"
 
   ExternalGuzzleClientInterface:
     class: GuzzleHttp\Client

--- a/src/Commands/ConfigureCommand.php
+++ b/src/Commands/ConfigureCommand.php
@@ -65,7 +65,7 @@ class ConfigureCommand extends AbstractCommand
     }
 
     /**
-     * @return array<string,string>
+     * @return array<string,array<string,string|boolean>>
      */
     private function getInputValues()
     {

--- a/src/Component/Http/HttpGuzzlClient.php
+++ b/src/Component/Http/HttpGuzzlClient.php
@@ -10,6 +10,7 @@
 namespace Chapi\Component\Http;
 
 use Chapi\Exception\HttpConnectionException;
+use Chapi\Entity\Http\AuthEntity;
 use GuzzleHttp\ClientInterface;
 
 class HttpGuzzlClient implements HttpClientInterface
@@ -23,21 +24,21 @@ class HttpGuzzlClient implements HttpClientInterface
     private $oGuzzelClient;
 
     /**
-     * @var array
+     * @var AuthEntity
      */
-    private $aGuzzelClientConfig;
+    private $oAuthEntity;
 
     /**
      * @param ClientInterface $oGuzzelClient
-     * @param array $aGuzzelClientConfig
+     * @param AuthEntity $oAuthEntity
      */
     public function __construct(
         ClientInterface $oGuzzelClient,
-        array $aGuzzelClientConfig = []
+        AuthEntity $oAuthEntity
     )
     {
         $this->oGuzzelClient = $oGuzzelClient;
-        $this->aGuzzelClientConfig = $aGuzzelClientConfig;
+        $this->oAuthEntity = $oAuthEntity;
     }
 
     /**
@@ -104,15 +105,13 @@ class HttpGuzzlClient implements HttpClientInterface
      * @return array
      */
     private function addAuthOption(array $aOptions) {
-        if (array_key_exists('username', $this->aGuzzelClientConfig)
-            && $this->aGuzzelClientConfig['username']
-            && array_key_exists('password', $this->aGuzzelClientConfig)
-            && $this->aGuzzelClientConfig['password']
+        if (!empty($this->oAuthEntity->username)
+            && !empty($this->oAuthEntity->password)
         )
         {
             $aOptions['auth'] = [
-                $this->aGuzzelClientConfig['username'],
-                $this->aGuzzelClientConfig['password']
+                $this->oAuthEntity->username,
+                $this->oAuthEntity->password
             ];
         }
 

--- a/src/Component/Http/HttpGuzzlClient.php
+++ b/src/Component/Http/HttpGuzzlClient.php
@@ -48,11 +48,7 @@ class HttpGuzzlClient implements HttpClientInterface
      */
     public function get($sUrl)
     {
-        $_aRequestOptions = [
-            'connect_timeout' => self::DEFAULT_CONNECTION_TIMEOUT,
-            'timeout' => self::DEFAULT_TIMEOUT
-        ];
-        $_aRequestOptions = $this->addAuthOption($_aRequestOptions);
+        $_aRequestOptions = $this->getDefaultRequestOptions();
 
         try
         {
@@ -76,8 +72,8 @@ class HttpGuzzlClient implements HttpClientInterface
      */
     public function postJsonData($sUrl, $mPostData)
     {
-        $_aRequestOptions = ['json' => $mPostData];
-        $_aRequestOptions = $this->addAuthOption($_aRequestOptions);
+        $_aRequestOptions = $this->getDefaultRequestOptions();
+        $_aRequestOptions['json'] = $mPostData;
 
         $_oRequest = $this->oGuzzelClient->createRequest('post', $sUrl, $_aRequestOptions);
         $_oResponse = $this->oGuzzelClient->send($_oRequest);
@@ -91,30 +87,34 @@ class HttpGuzzlClient implements HttpClientInterface
      */
     public function delete($sUrl)
     {
-        $_aRequestOptions = [];
-        $_aRequestOptions = $this->addAuthOption($_aRequestOptions);
-
+        $_aRequestOptions = $this->getDefaultRequestOptions();
         $_oResponse = $this->oGuzzelClient->delete($sUrl, $_aRequestOptions);
         return new HttpGuzzlResponse($_oResponse);
     }
 
     /**
-     * Adds authentication headers according the Guzzle http options.
+     * Returns default options for the HTTP request.
+     * If an username and password is provided, auth
+     * header will be applied as well.
      *
-     * @param array $aOptions
      * @return array
      */
-    private function addAuthOption(array $aOptions) {
+    private function getDefaultRequestOptions() {
+        $_aRequestOptions = [
+            'connect_timeout' => self::DEFAULT_CONNECTION_TIMEOUT,
+            'timeout' => self::DEFAULT_TIMEOUT
+        ];
+
         if (!empty($this->oAuthEntity->username)
             && !empty($this->oAuthEntity->password)
         )
         {
-            $aOptions['auth'] = [
+            $_aRequestOptions['auth'] = [
                 $this->oAuthEntity->username,
                 $this->oAuthEntity->password
             ];
         }
 
-        return $aOptions;
+        return $_aRequestOptions;
     }
 }

--- a/src/Entity/Http/AuthEntity.php
+++ b/src/Entity/Http/AuthEntity.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @package: chapi
+ *
+ * @author:  agrunwald
+ * @since:   2016-03-07
+ *
+ */
+
+namespace Chapi\Entity\Http;
+
+class AuthEntity
+{
+    /**
+     * @var string
+     */
+    public $username = '';
+
+    /**
+     * @var string
+     */
+    public $password = '';
+
+    /**
+     * @param string $sUsername
+     * @param string $sPassword
+     */
+    public function __construct($sUsername, $sPassword)
+    {
+        $this->username = $sUsername;
+        $this->password = $sPassword;
+    }
+}

--- a/test/unit/Command/ConfigureCommandTest.php
+++ b/test/unit/Command/ConfigureCommandTest.php
@@ -54,6 +54,8 @@ class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
     public function testConfigureWithoutArgumentsSuccess()
     {
         $this->oInput->getOption(Argument::exact('chronos_url'))->shouldBeCalledTimes(1)->willReturn(null);
+        $this->oInput->getOption(Argument::exact('chronos_http_username'))->shouldBeCalledTimes(1)->willReturn(null);
+        $this->oInput->getOption(Argument::exact('chronos_http_password'))->shouldBeCalledTimes(1)->willReturn(null);
         $this->oInput->getOption(Argument::exact('cache_dir'))->shouldBeCalledTimes(1)->willReturn(null);
         $this->oInput->getOption(Argument::exact('repository_dir'))->shouldBeCalledTimes(1)->willReturn(null);
 
@@ -83,6 +85,8 @@ class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
     public function testConfigureWithArgumentsSuccess()
     {
         $this->oInput->getOption(Argument::exact('chronos_url'))->shouldBeCalledTimes(1)->willReturn('http://url.com');
+        $this->oInput->getOption(Argument::exact('chronos_http_username'))->shouldBeCalledTimes(1)->willReturn('username');
+        $this->oInput->getOption(Argument::exact('chronos_http_password'))->shouldBeCalledTimes(1)->willReturn('password');
         $this->oInput->getOption(Argument::exact('cache_dir'))->shouldBeCalledTimes(1)->willReturn('/cacheDir');
         $this->oInput->getOption(Argument::exact('repository_dir'))->shouldBeCalledTimes(1)->willReturn('/path');
 
@@ -111,6 +115,8 @@ class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
     public function testConfigureWithAndWithoutArgumentsSuccess()
     {
         $this->oInput->getOption(Argument::exact('chronos_url'))->shouldBeCalledTimes(1)->willReturn('http://url.com');
+        $this->oInput->getOption(Argument::exact('chronos_http_username'))->shouldBeCalledTimes(1)->willReturn(null);
+        $this->oInput->getOption(Argument::exact('chronos_http_password'))->shouldBeCalledTimes(1)->willReturn(null);
         $this->oInput->getOption(Argument::exact('cache_dir'))->shouldBeCalledTimes(1)->willReturn(null);
         $this->oInput->getOption(Argument::exact('repository_dir'))->shouldBeCalledTimes(1)->willReturn(null);
 
@@ -140,6 +146,8 @@ class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
     public function testConfigureWithoutArgumentsFailure()
     {
         $this->oInput->getOption(Argument::exact('chronos_url'))->shouldBeCalledTimes(1)->willReturn('http://url.com');
+        $this->oInput->getOption(Argument::exact('chronos_http_username'))->shouldBeCalledTimes(1)->willReturn(null);
+        $this->oInput->getOption(Argument::exact('chronos_http_password'))->shouldBeCalledTimes(1)->willReturn(null);
         $this->oInput->getOption(Argument::exact('cache_dir'))->shouldBeCalledTimes(1)->willReturn(null);
         $this->oInput->getOption(Argument::exact('repository_dir'))->shouldBeCalledTimes(1)->willReturn(null);
 

--- a/test/unit/Command/ConfigureCommandTest.php
+++ b/test/unit/Command/ConfigureCommandTest.php
@@ -64,7 +64,7 @@ class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
             Argument::type('Symfony\Component\Console\Output\OutputInterface'),
             Argument::type('Symfony\Component\Console\Question\Question')
         )
-            ->shouldBeCalledTimes(3)
+            ->shouldBeCalledTimes(5)
             ->willReturn('stringInput')
         ;
 
@@ -125,7 +125,7 @@ class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
             Argument::type('Symfony\Component\Console\Output\OutputInterface'),
             Argument::type('Symfony\Component\Console\Question\Question')
         )
-            ->shouldBeCalledTimes(2)
+            ->shouldBeCalledTimes(4)
             ->willReturn('inputValue')
         ;
 
@@ -156,7 +156,7 @@ class ConfigureCommandTest extends \PHPUnit_Framework_TestCase
             Argument::type('Symfony\Component\Console\Output\OutputInterface'),
             Argument::type('Symfony\Component\Console\Question\Question')
         )
-            ->shouldBeCalledTimes(2)
+            ->shouldBeCalledTimes(4)
             ->willReturn('')
         ;
 

--- a/test/unit/Component/Http/HttpGuzzlClientTest.php
+++ b/test/unit/Component/Http/HttpGuzzlClientTest.php
@@ -12,6 +12,7 @@ namespace unit\Component\Http;
 
 
 use Chapi\Component\Http\HttpGuzzlClient;
+use Chapi\Entity\Http\AuthEntity;
 use Prophecy\Argument;
 
 class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
@@ -32,6 +33,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
     {
         $_sUrl = '/url/for/test';
 
+        $_oAuthEntitiy = new AuthEntity("", "");
         $_aGuzzleOptions = [
             'connect_timeout' => HttpGuzzlClient::DEFAULT_CONNECTION_TIMEOUT,
             'timeout' => HttpGuzzlClient::DEFAULT_TIMEOUT
@@ -42,7 +44,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             ->willReturn($this->oGuzzlResponse->reveal())
         ;
 
-        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal());
+        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_oAuthEntitiy);
 
         $this->assertInstanceOf('Chapi\Component\Http\HttpClientResponseInterface', $_oHttpGuzzlClient->get($_sUrl));
     }
@@ -54,6 +56,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             'username' => 'user',
             'password' => 'pass'
         ];
+        $_oAuthEntitiy = new AuthEntity($_aAuth['username'], $_aAuth['password']);
         $_aGuzzleOptions = [
             'connect_timeout' => HttpGuzzlClient::DEFAULT_CONNECTION_TIMEOUT,
             'timeout' => HttpGuzzlClient::DEFAULT_TIMEOUT,
@@ -65,7 +68,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             ->willReturn($this->oGuzzlResponse->reveal())
         ;
 
-        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_aAuth);
+        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_oAuthEntitiy);
 
         $_oResponse = $_oHttpGuzzlClient->get($_sUrl);
         $this->assertInstanceOf('Chapi\Component\Http\HttpClientResponseInterface', $_oResponse);
@@ -78,6 +81,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
     {
         $_sUrl = '/url/for/test';
 
+        $_oAuthEntitiy = new AuthEntity("", "");
         $_aGuzzleOptions = [
             'connect_timeout' => HttpGuzzlClient::DEFAULT_CONNECTION_TIMEOUT,
             'timeout' => HttpGuzzlClient::DEFAULT_TIMEOUT
@@ -93,7 +97,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             ->willReturn('http://www.abc.com')
         ;
 
-        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal());
+        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_oAuthEntitiy);
 
         $this->assertNull($_oHttpGuzzlClient->get($_sUrl));
     }
@@ -102,9 +106,8 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
     {
         $_sUrl = '/url/for/test';
         $_aPostData = ['data' => [1, 2, 3]];
-
+        $_oAuthEntitiy = new AuthEntity("", "");
         $_oRequestInterface = $this->prophesize('GuzzleHttp\Message\RequestInterface');
-
 
         $this->oGuzzelClient->createRequest(Argument::exact('post'), Argument::exact($_sUrl), Argument::exact(['json' => $_aPostData]))
             ->shouldBeCalledTimes(1)
@@ -116,7 +119,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             ->willReturn($this->oGuzzlResponse->reveal())
         ;
 
-        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal());
+        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_oAuthEntitiy);
 
         $this->assertInstanceOf('Chapi\Component\Http\HttpClientResponseInterface', $_oHttpGuzzlClient->postJsonData($_sUrl, $_aPostData));
     }
@@ -128,6 +131,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             'username' => 'user',
             'password' => 'pass'
         ];
+        $_oAuthEntitiy = new AuthEntity($_aAuth['username'], $_aAuth['password']);
         $_aPostData = ['data' => [1, 2, 3]];
         $_aGuzzleOptions = [
             'json' => $_aPostData,
@@ -144,7 +148,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalledTimes(1)
             ->willReturn($this->oGuzzlResponse->reveal());
 
-        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_aAuth);
+        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_oAuthEntitiy);
 
         $this->assertInstanceOf('Chapi\Component\Http\HttpClientResponseInterface', $_oHttpGuzzlClient->postJsonData($_sUrl, $_aPostData));
     }
@@ -153,12 +157,13 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
     {
         $_sUrl = '/url/for/test';
 
+        $_oAuthEntitiy = new AuthEntity("", "");
         $this->oGuzzelClient->delete(Argument::exact($_sUrl), [])
             ->shouldBeCalledTimes(1)
             ->willReturn($this->oGuzzlResponse->reveal())
         ;
 
-        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal());
+        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_oAuthEntitiy);
 
         $this->assertInstanceOf('Chapi\Component\Http\HttpClientResponseInterface', $_oHttpGuzzlClient->delete($_sUrl));
     }
@@ -170,6 +175,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             'username' => 'user',
             'password' => 'pass'
         ];
+        $_oAuthEntitiy = new AuthEntity($_aAuth['username'], $_aAuth['password']);
         $_aGuzzleOptions = [
             'auth' => [$_aAuth['username'], $_aAuth['password']]
         ];
@@ -179,7 +185,7 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
             ->willReturn($this->oGuzzlResponse->reveal())
         ;
 
-        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_aAuth);
+        $_oHttpGuzzlClient = new HttpGuzzlClient($this->oGuzzelClient->reveal(), $_oAuthEntitiy);
 
         $this->assertInstanceOf('Chapi\Component\Http\HttpClientResponseInterface', $_oHttpGuzzlClient->delete($_sUrl));
     }

--- a/test/unit/Component/Http/HttpGuzzlClientTest.php
+++ b/test/unit/Component/Http/HttpGuzzlClientTest.php
@@ -106,10 +106,15 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
     {
         $_sUrl = '/url/for/test';
         $_aPostData = ['data' => [1, 2, 3]];
+        $_aGuzzleOptions = [
+            'connect_timeout' => HttpGuzzlClient::DEFAULT_CONNECTION_TIMEOUT,
+            'timeout' => HttpGuzzlClient::DEFAULT_TIMEOUT,
+            'json' => $_aPostData
+        ];
         $_oAuthEntitiy = new AuthEntity("", "");
         $_oRequestInterface = $this->prophesize('GuzzleHttp\Message\RequestInterface');
 
-        $this->oGuzzelClient->createRequest(Argument::exact('post'), Argument::exact($_sUrl), Argument::exact(['json' => $_aPostData]))
+        $this->oGuzzelClient->createRequest(Argument::exact('post'), Argument::exact($_sUrl), Argument::exact($_aGuzzleOptions))
             ->shouldBeCalledTimes(1)
             ->willReturn($_oRequestInterface->reveal())
         ;
@@ -134,6 +139,8 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
         $_oAuthEntitiy = new AuthEntity($_aAuth['username'], $_aAuth['password']);
         $_aPostData = ['data' => [1, 2, 3]];
         $_aGuzzleOptions = [
+            'connect_timeout' => HttpGuzzlClient::DEFAULT_CONNECTION_TIMEOUT,
+            'timeout' => HttpGuzzlClient::DEFAULT_TIMEOUT,
             'json' => $_aPostData,
             'auth' => [$_aAuth['username'], $_aAuth['password']]
         ];
@@ -156,9 +163,12 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
     public function testDeleteSuccess()
     {
         $_sUrl = '/url/for/test';
-
+        $_aGuzzleOptions = [
+            'connect_timeout' => HttpGuzzlClient::DEFAULT_CONNECTION_TIMEOUT,
+            'timeout' => HttpGuzzlClient::DEFAULT_TIMEOUT,
+        ];
         $_oAuthEntitiy = new AuthEntity("", "");
-        $this->oGuzzelClient->delete(Argument::exact($_sUrl), [])
+        $this->oGuzzelClient->delete(Argument::exact($_sUrl), Argument::exact($_aGuzzleOptions))
             ->shouldBeCalledTimes(1)
             ->willReturn($this->oGuzzlResponse->reveal())
         ;
@@ -177,6 +187,8 @@ class HttpGuzzlClientTest extends \PHPUnit_Framework_TestCase
         ];
         $_oAuthEntitiy = new AuthEntity($_aAuth['username'], $_aAuth['password']);
         $_aGuzzleOptions = [
+            'connect_timeout' => HttpGuzzlClient::DEFAULT_CONNECTION_TIMEOUT,
+            'timeout' => HttpGuzzlClient::DEFAULT_TIMEOUT,
             'auth' => [$_aAuth['username'], $_aAuth['password']]
         ];
 


### PR DESCRIPTION
Chronos supports a configuration setting called `http_credentials` to protect the WEB UI and HTTP API.
This PR adds support for Username and Password to enable chapi to work with a Chronos instance with activated `http_credentials`.

Some design decisions / implementation details you should consider during review:

* **Chapi\Component\Http\HttpGuzzlClient**: I decided to inject username and password via Array into `HttpGuzzlClient`. With this the usage of username and password is transparent and you don't have to take special attention to it once you implement a new command for chapi. The constructor of `HttpGuzzlClient` gets a Instance as first argument and an array as second. For the usage of DIC this is transparent.
* **ConfigureCommand**: I implemented optional questions in the configure command. Before all values were required and a simple "Enter"-Hit throws an error. Now you can define if your Question requires an answer or not. The configuration will be stored in a backwards compatible way. Old configurations will be work with the new version.
* **Unit Tests**: I decided to copy and extend the existing unit tests instead of adding more complexity to them due to arguments. Why? Because then i would reach the point were the tests need tests as well to cover their complexity.

This implementation was tested against a docker setup of Chronos by bobrik: https://github.com/bobrik/mesos-compose

Here we go. Looking for feedback.