### PR TITLE
Fix update operation. Adds forcePullImage Option for docker

### DIFF
--- a/src/BusinessCase/JobManagement/MarathonStoreJobBusinessCase.php
+++ b/src/BusinessCase/JobManagement/MarathonStoreJobBusinessCase.php
@@ -256,13 +256,11 @@ class MarathonStoreJobBusinessCase extends AbstractStoreJobBusinessCase implemen
     {
         if ($this->oJobIndexService->isJobInIndex($sAppId))
         {
-            $_bRemoved = $this->oJobRepositoryRemote->removeJob($sAppId);
-
             $_oUpdatedConfig = $this->oJobRepositoryLocal->getJob($sAppId);
-            $_bAddedBack = $this->oJobRepositoryRemote->addJob($_oUpdatedConfig);
+            $_bAddedBack = $this->oJobRepositoryRemote->updateJob($_oUpdatedConfig);
 
             // updated
-            if ($_bRemoved && $_bAddedBack)
+            if ($_bAddedBack)
             {
                 $this->oJobIndexService->removeJob($sAppId);
                 $this->oLogger->notice(sprintf(

--- a/src/Component/RemoteClients/MarathonApiClient.php
+++ b/src/Component/RemoteClients/MarathonApiClient.php
@@ -55,7 +55,8 @@ class MarathonApiClient implements ApiClientInterface
      */
     public function updatingJob(JobEntityInterface $oJobEntity)
     {
-        $_sTargetEndpoint = '/v2/apps';
+        $_sJobName = $oJobEntity->getKey();
+        $_sTargetEndpoint = '/v2/apps/' . $_sJobName;
 
         $_oResponse = $this->oHttpClient->putJsonData($_sTargetEndpoint, $oJobEntity);
         return ($_oResponse->getStatusCode() == 200);

--- a/src/Entity/Marathon/AppEntity/Docker.php
+++ b/src/Entity/Marathon/AppEntity/Docker.php
@@ -28,6 +28,8 @@ class Docker
 
     public $privileged = false;
 
+    public $forcePullImage = false;
+
     /**
      * @var DockerParameters
      */

--- a/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
+++ b/test/unit/BusinessCase/JobManagement/MarathonStoreJobBusinessCaseTest.php
@@ -690,12 +690,7 @@ class MarathonStoreJobBusinessCaseTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalled();
 
         $this->oJobRepositoryRemote
-            ->removeJob(Argument::exact("/local/update1"))
-            ->willReturn(true)
-            ->shouldBeCalled();
-
-        $this->oJobRepositoryRemote
-            ->addJob(Argument::exact($_oUpdatedApp))
+            ->updateJob(Argument::exact($_oUpdatedApp))
             ->willReturn(true)
             ->shouldBeCalled();
 

--- a/test/unit/Component/RemoteClients/MarathonApiClientTest.php
+++ b/test/unit/Component/RemoteClients/MarathonApiClientTest.php
@@ -78,7 +78,7 @@ class MarathonApiClientTest extends \PHPUnit_Framework_TestCase
             ->willReturn(200);
 
         $this->oHttpClient
-            ->putJsonData(Argument::exact('/v2/apps'), Argument::exact($oAppEntity))
+            ->putJsonData(Argument::exact('/v2/apps//some/id'), Argument::exact($oAppEntity))
             ->willReturn($this->oHttpResponse->reveal());
 
         $oMarathonApiClient = new MarathonApiClient($this->oHttpClient->reveal());


### PR DESCRIPTION
Previously, for the update of the app, chapi deleted the current version and launched a new one. This was a problem because
1) messes up dependencies if present
2) cannot start the app again because when trying to launch a new one, the app was still in the process of removing. So the deployment was locked.

This PR adjusts the update app endpoint properly and uses this to update the app.

Bonus: Adds forcePullImage parameter in docker subentity as it wasn't present before. 

@msiebeneicher 