### PR TITLE
Calculate correct difference in HealthCheck

### DIFF
--- a/src/BusinessCase/Comparison/MarathonJobComparisonBusinessCase.php
+++ b/src/BusinessCase/Comparison/MarathonJobComparisonBusinessCase.php
@@ -145,7 +145,7 @@ class MarathonJobComparisonBusinessCase extends AbstractJobComparisionBusinessCa
             {
                 foreach ($aValuesB as $_mValueB)
                 {
-                    if ($_mValueA == $_mValueB)
+                    if ($this->isEqual($_mValueA,$_mValueB))
                     {
                         continue 2;
                     }

--- a/src/Entity/Marathon/AppEntity/HealthCheck.php
+++ b/src/Entity/Marathon/AppEntity/HealthCheck.php
@@ -57,5 +57,6 @@ class HealthCheck implements \JsonSerializable
         {
             unset($_aRet["port"]);
         }
+        return $_aRet;
     }
 }

--- a/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
+++ b/test/unit/BusinessCase/Comparison/MarathonJobComparisonBusinessCaseTest.php
@@ -11,6 +11,7 @@ namespace unit\BusinessCase\Comparision;
 
 
 use Chapi\BusinessCase\Comparison\MarathonJobComparisonBusinessCase;
+use Chapi\Entity\Marathon\AppEntity\HealthCheck;
 use Chapi\Entity\Marathon\MarathonAppEntity;
 use ChapiTest\src\TestTraits\AppEntityTrait;
 use Prophecy\Argument;
@@ -500,6 +501,33 @@ class MarathonJobComparisonBusinessCaseTest extends \PHPUnit_Framework_TestCase
                 'dependencies',
                 new MarathonAppEntity([ 'dependencies' => [ (object)[ 'X' => 'abc' ] ] ]),
                 new MarathonAppEntity([ 'dependencies' => [ (object)[ 'Y' => 'abc' ] ] ])
+            ]
+        );
+
+        $this->assertFalse($result);
+    }
+
+    public function testArrayOfSubentitiesEqual()
+    {
+        $class = new \ReflectionClass(MarathonJobComparisonBusinessCase::class);
+        $method = $class->getMethod('isEqual');
+        $method->setAccessible(true);
+
+        $healthCheckA = new HealthCheck();
+        $healthCheckA->port = 0;
+
+        $healthCheckB = new HealthCheck();
+
+        $result = $method->invokeArgs(
+            new MarathonJobComparisonBusinessCase(
+                $this->oLocalRepository->reveal(),
+                $this->oRemoteRepository->reveal(),
+                $this->oDiffCompare->reveal()
+            ),
+            [
+                'dependencies',
+                [$healthCheckA],
+                [$healthCheckB]
             ]
         );
 

--- a/test/unit/Entity/Marathon/AppEntity/HealthCheckTest.php
+++ b/test/unit/Entity/Marathon/AppEntity/HealthCheckTest.php
@@ -14,7 +14,8 @@ use Chapi\Entity\Marathon\AppEntity\HealthCheck;
 class HealthCheckTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testCheckAllKeysAreCorrect() {
+    public function testCheckAllKeysAreCorrect()
+    {
         $_aKeys = ["command", "gracePeriodSeconds", "intervalSeconds",
                     "maxConsecutiveFailures", "path", "port", "portIndex", "protocol" , "timeoutSeconds"];
 
@@ -24,7 +25,8 @@ class HealthCheckTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testHealthCheckIsSetProperly() {
+    public function testHealthCheckIsSetProperly()
+    {
         $aData = [
             "protocol" => "HTTP",
             "path" => "/health",
@@ -48,5 +50,50 @@ class HealthCheckTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(40, $oHealthCheck->timeoutSeconds);
         $this->assertEquals(4, $oHealthCheck->maxConsecutiveFailures);
         $this->assertTrue(isset($oHealthCheck->command));
+    }
+
+    public function testHealthCheckGivesProperJson()
+    {
+        $_sExpectedData = '{"protocol":"HTTP","path":"\/","gracePeriodSeconds":10,"intervalSeconds":10,"portIndex":0,"port":0,"timeoutSeconds":20,"maxConsecutiveFailures":3,"command":{"value":"someCommand"}}';
+
+        $aData = [
+            "protocol" => "HTTP",
+            "path" => "/",
+            "gracePeriodSeconds" => 10,
+            "intervalSeconds" => 10,
+            "portIndex" => 0,
+            "port" => 0,
+            "timeoutSeconds" => 20,
+            "maxConsecutiveFailures" => 3,
+            "command" => ["value" => "someCommand"]
+        ];
+
+        $oHealthCheck = new HealthCheck($aData);
+
+        $_sGotData = json_encode($oHealthCheck);
+
+        $this->assertEquals($_sExpectedData, $_sGotData);
+    }
+
+    public function testHealthCheckHasPortUnsetWithNullValue()
+    {
+        $_sExpectedData = '{"protocol":"HTTP","path":"\/","gracePeriodSeconds":10,"intervalSeconds":10,"portIndex":0,"timeoutSeconds":20,"maxConsecutiveFailures":3,"command":{"value":"someCommand"}}';
+
+        $aData = [
+            "protocol" => "HTTP",
+            "path" => "/",
+            "gracePeriodSeconds" => 10,
+            "intervalSeconds" => 10,
+            "portIndex" => 0,
+            "timeoutSeconds" => 20,
+            "maxConsecutiveFailures" => 3,
+            "command" => ["value" => "someCommand"]
+        ];
+
+        $oHealthCheck = new HealthCheck($aData);
+
+        $_sGotData = json_encode($oHealthCheck);
+
+        $this->assertEquals($_sExpectedData, $_sGotData);
     }
 }


### PR DESCRIPTION
Fix the marathon job comparision for array with numerical keys. Fix healthCheck object to return jsonSerializable array.