### PR TITLE
GetJobDiff not ignoring non-existing portDefinitions

### DIFF
--- a/src/BusinessCase/Comparison/AbstractJobComparisionBusinessCase.php
+++ b/src/BusinessCase/Comparison/AbstractJobComparisionBusinessCase.php
@@ -156,6 +156,7 @@ abstract class AbstractJobComparisionBusinessCase implements JobComparisonInterf
             $_oRemoteEntity = $this->getEntitySetWithDefaults();
         }
 
+        $this->preCompareModifications($_oLocalEntity, $_oRemoteEntity);
         $_aNonIdenticalProps = $this->compareJobEntities(
             $_oLocalEntity,
             $_oRemoteEntity


### PR DESCRIPTION
For the method getJobDiff in marathon compare business case, the precompare modification isn't called. And due to this, when calculating job diff, the things that needs to be ignored (like port definitions when it is not in the local job config) aren't. 
 
This PR fixes that. 